### PR TITLE
診断テストのページ入れ替え機能と保存機能の実装

### DIFF
--- a/src/app/components/QuestionForm.tsx
+++ b/src/app/components/QuestionForm.tsx
@@ -1,5 +1,41 @@
 'use client'
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import Link from 'next/link';
+
+const Button = styled.button`
+  background-color: #000;
+  color: white;
+  padding: 15px 30px;
+  font-size: 1rem;
+  border: none;
+  border-radius: 5px;
+  text-decoration: none;
+  cursor: pointer;
+  margin-top: 1rem;
+
+  &:hover {
+    background-color: #333;
+  }
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  color: black;
+  background: black;
+  padding: 2rem;
+  margin-top: 20px;
+`;
+
+
+const Title = styled.h1`
+  font-size: 2rem;
+  font-weight: bold;
+  color: white;
+`;
 
 const QuestionTitle = styled.h2`
   font-size: 1.25rem;
@@ -8,55 +44,109 @@ const QuestionTitle = styled.h2`
 `;
 
 const OptionList = styled.div`
-  display: flex;
   flex-wrap: wrap;
   gap: 1rem;
 `;
+
 
 const OptionItem = styled.label`
   display: flex;
   align-items: center;
   background: #3333cc;
-  padding: 0.5rem 1rem;
+  margin: 4px;
   border-radius: 5px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   cursor: pointer;
 
   input {
     margin-right: 0.5rem;
+    height: 20px;
+    width: 20px;
   }
 `;
 
 const Content = styled.p`
   margin: 0;
-  font-size: 1rem;
+  font-size: 1.5rem;
   color: white;
 `;
 
 
+
 export default function QuestionForm(headers) {
-  console.log(headers)
+  const [currentHeaderIndex, setCurrentHeaderIndex] = useState(0);
+  const handleNext = () => {
+    if (currentHeaderIndex < headers.headers.length - 1) {
+      setCurrentHeaderIndex(currentHeaderIndex + 1);
+    }
+  };
+
+  const handleSubmit = async () => {
+    try {
+      for (const key in answers) {
+        const answer = answers[key];
+        const response = await fetch('http://localhost:8086/diagnosis_answer', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            title: answer.title,
+            point: answer.point,
+            question_id: answer.question_id
+          }),
+        });
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const responseData = await response.json();
+        console.log('Successfully submitted:', responseData);
+      }
+    } catch (error) {
+      console.error('Error submitting answers:', error);
+    }
+  };
+
+  const currentHeader = headers.headers[currentHeaderIndex];
+
+  const [answers, setAnswers] = useState({});
+  const handleChange = (questionIndex, choicePoint, questionId, choiceTitle) => {
+    setAnswers(prevAnswers => ({
+      ...prevAnswers,
+      [questionIndex]: { point: choicePoint, question_id: questionId, title: choiceTitle }
+    }));
+  };
+  console.log(headers.headers)
+
   return (
     <>
-      <QuestionTitle>{headers.title}</QuestionTitle>
-      {headers.questions.questions.map((question, index) => (
-        <div key={index}>
-          <QuestionTitle>{question.title}</QuestionTitle>
-          <OptionList>
-            {question.choices.map((choice, idx) => (
-              <OptionItem key={idx}>
-                <input
-                  type={question.type}
-                  name={`question-${index}`}
-                  value={choice.point}
-                  onChange={() => handleChange(index, choice.point, question.id, choice.title)}
-                />
-                <Content>{choice.title}</Content>
-              </OptionItem>
-            ))}
-          </OptionList>
-        </div>
-      ))}
+        <Title>{currentHeader.title}</Title>
+      <Container>
+        <OptionList>
+          {currentHeader.questions.map((question, index) => (
+            <div key={index}>
+
+              <Title>{question.title}</Title>
+              {question.choices.map((choice, idx) => (
+                <OptionItem key={idx}>
+                  <input
+                    type={question.type}
+                    name={`question-${question.id}`}
+                    value={choice.point}
+                    onChange={() => handleChange(index, choice.point, question.id, choice.title)}
+                  />
+                  <Content>{choice.title}</Content>
+                </OptionItem>
+              ))}
+            </div>
+          ))}
+        </OptionList>
+        {currentHeaderIndex < headers.headers.length - 1 ? (
+          <Button onClick={handleNext}>次へ</Button>
+        ) : (
+          <Button onClick={handleSubmit}>保存</Button>
+        )}
+      </Container>
     </>
   );
 }

--- a/src/app/components/QuestionForm.tsx
+++ b/src/app/components/QuestionForm.tsx
@@ -1,0 +1,62 @@
+'use client'
+import styled from 'styled-components';
+
+const QuestionTitle = styled.h2`
+  font-size: 1.25rem;
+  color: #00cc99;
+  margin-bottom: 1rem;
+`;
+
+const OptionList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+`;
+
+const OptionItem = styled.label`
+  display: flex;
+  align-items: center;
+  background: #3333cc;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+
+  input {
+    margin-right: 0.5rem;
+  }
+`;
+
+const Content = styled.p`
+  margin: 0;
+  font-size: 1rem;
+  color: white;
+`;
+
+
+export default function QuestionForm(headers) {
+  console.log(headers)
+  return (
+    <>
+      <QuestionTitle>{headers.title}</QuestionTitle>
+      {headers.questions.questions.map((question, index) => (
+        <div key={index}>
+          <QuestionTitle>{question.title}</QuestionTitle>
+          <OptionList>
+            {question.choices.map((choice, idx) => (
+              <OptionItem key={idx}>
+                <input
+                  type={question.type}
+                  name={`question-${index}`}
+                  value={choice.point}
+                  onChange={() => handleChange(index, choice.point, question.id, choice.title)}
+                />
+                <Content>{choice.title}</Content>
+              </OptionItem>
+            ))}
+          </OptionList>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -62,7 +62,6 @@ export default function DiagnosticTest() {
     fetchQuestions();
   }, []);
 
-  console.log(headers)
   return (
     <>
       <Header />

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Header from '../components/Header';
+import QuestionForm from '../components/QuestionForm';
 
 const PageContainer = styled.div`
   display: flex;
@@ -34,46 +35,15 @@ const Title = styled.h1`
   font-weight: bold;
 `;
 
-const Content = styled.p`
-  margin: 0;
-  font-size: 1rem;
-  color: white;
-`;
-
 const QuestionSection = styled.div`
   width: 100%;
   max-width: 800px;
   margin-bottom: 2rem;
 `;
 
-const QuestionTitle = styled.h2`
-  font-size: 1.25rem;
-  color: #00cc99;
-  margin-bottom: 1rem;
-`;
-
-const OptionList = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-`;
-
-const OptionItem = styled.label`
-  display: flex;
-  align-items: center;
-  background: #3333cc;
-  padding: 0.5rem 1rem;
-  border-radius: 5px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  cursor: pointer;
-
-  input {
-    margin-right: 0.5rem;
-  }
-`;
-
 export default function DiagnosticTest() {
   const [diagnosisTitle, setDiagnosisTitle] = useState('');
+  const [headers, setHeaders] = useState([]);
   const [questions, setQuestions] = useState([]);
   const [answers, setAnswers] = useState({});
 
@@ -83,7 +53,8 @@ export default function DiagnosticTest() {
         const response = await fetch('http://localhost:8086/diagnosis/1'); // IDは1を仮定
         const data = await response.json();
         setDiagnosisTitle(data.title);
-        setQuestions(data.questions);
+        setHeaders(data.headers);
+        // setQuestions(data.questions);
       } catch (error) {
         console.error('Error fetching questions:', error);
       }
@@ -130,22 +101,10 @@ export default function DiagnosticTest() {
       <Header />
       <PageContainer>
         <Title>{diagnosisTitle}</Title>
-        {questions.map((question, index) => (
+        {headers.map((questions, index) => (
           <QuestionSection key={index}>
-            <QuestionTitle>{question.title}</QuestionTitle>
-            <OptionList>
-              {question.choices.map((choice, idx) => (
-                <OptionItem key={idx}>
-                  <input
-                    type={question.type}
-                    name={`question-${index}`}
-                    value={choice.point}
-                    onChange={() => handleChange(index, choice.point, question.id, choice.title)}
-                  />
-                  <Content>{choice.title}</Content>
-                </OptionItem>
-              ))}
-            </OptionList>
+            <QuestionForm
+              questions={questions} />
           </QuestionSection>
         ))}
         <Button onClick={handleSubmit}>保存</Button>

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -45,7 +45,6 @@ export default function DiagnosticTest() {
   const [diagnosisTitle, setDiagnosisTitle] = useState('');
   const [headers, setHeaders] = useState([]);
   const [questions, setQuestions] = useState([]);
-  const [answers, setAnswers] = useState({});
 
   useEffect(() => {
     const fetchQuestions = async () => {
@@ -63,51 +62,17 @@ export default function DiagnosticTest() {
     fetchQuestions();
   }, []);
 
-  const handleChange = (questionIndex, choicePoint, questionId, questionTitle) => {
-    setAnswers(prevAnswers => ({
-      ...prevAnswers,
-      [questionIndex]: { point: choicePoint, question_id: questionId, title: questionTitle }
-    }));
-  };
-
-  const handleSubmit = async () => {
-    try {
-      for (const key in answers) {
-        const answer = answers[key];
-        const response = await fetch('http://localhost:8086/diagnosis_answer', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            title: answer.title,
-            point: answer.point,
-            question_id: answer.question_id
-          }),
-        });
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
-        }
-        const responseData = await response.json();
-        console.log('Successfully submitted:', responseData);
-      }
-    } catch (error) {
-      console.error('Error submitting answers:', error);
-    }
-  };
-
+  console.log(headers)
   return (
     <>
       <Header />
       <PageContainer>
         <Title>{diagnosisTitle}</Title>
-        {headers.map((questions, index) => (
-          <QuestionSection key={index}>
-            <QuestionForm
-              questions={questions} />
-          </QuestionSection>
-        ))}
-        <Button onClick={handleSubmit}>保存</Button>
+        {headers.length > 0 ? (
+          <QuestionForm headers={headers} />
+        ) : (
+          <p>Loading...</p>
+        )}
       </PageContainer>
     </>
   );

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -1,15 +1,170 @@
 'use client'
 import styled from 'styled-components';
-import Link from 'next/link';
 import Header from '../components/Header'
-import TopPageFv from '../components/TopPageFv.tsx'
-import TopPageSection from '../components/TopPageSection.tsx'
-import Divider from '../components/Divider.tsx'
 
-export default function Home() {
+const PageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  color: black;
+  background: black;
+  padding: 2rem;
+  margin-top: 20px;
+`;
+
+const Button = styled.button`
+  background-color: #00cc99;
+  color: white;
+  padding: 10px 20px;
+  font-size: 1rem;
+  border-radius: 5px;
+  text-decoration: none;
+  margin-top: 1rem;
+  display: inline-block;
+
+  &:hover {
+    background-color: #009977;
+  }
+`;
+
+
+const Title = styled.h1`
+  font-size: 2rem;
+  font-weight: bold;
+`;
+
+const Content = styled.p`
+  margin: 0;
+  font-size: 1rem;
+  color: white;
+`;
+
+const QuestionSection = styled.div`
+  width: 100%;
+  max-width: 800px;
+  margin-bottom: 2rem;
+`;
+
+const QuestionTitle = styled.h2`
+  font-size: 1.25rem;
+  color: #00cc99;
+  margin-bottom: 1rem;
+`;
+
+const OptionList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+`;
+
+const OptionItem = styled.label`
+  display: flex;
+  align-items: center;
+  background: #3333CC;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+
+  input {
+    margin-right: 0.5rem;
+  }
+`;
+
+export default function DiagnosticTest() {
   return (
     <>
       <Header />
+      <PageContainer>
+        <QuestionSection>
+          <QuestionTitle>お酒を飲む頻度とそのスタイルを教えてください</QuestionTitle>
+          <OptionList>
+            <OptionItem>
+              <input type="radio" name="skill" value="営業(個人)" />
+              <Content>お酒はほとんど飲まない</Content>
+            </OptionItem>
+            <OptionItem>
+              <input type="radio" name="skill" value="" />
+              <Content>お酒は週1、2回程度飲む。お酒にあまり強くない、もしくは普通のため、付き合いでちょっと飲む程度</Content>
+            </OptionItem>
+            <OptionItem>
+              <input type="radio" name="skill" value="" />
+              <Content>ほとんど毎日飲む。好きな酒のこだわりはなく、手持ち無沙汰で飲んでいる。お酒を飲める人はかっこいいと思う</Content>
+            </OptionItem>
+            <OptionItem>
+              <input type="radio" name="skill" value="" />
+              <Content>毎日飲まなきゃやってらんない。酒の味が大好きで、仲間と飲むのが楽しいから毎日飲む</Content>
+            </OptionItem>
+
+            <OptionItem>
+              <input type="radio" name="skill" value="" />
+              <Content>毎日飲まなきゃやってらんない。たいてい一人で飲む。そして本当は酒はあまり好きじゃない</Content>
+            </OptionItem>
+          </OptionList>
+        </QuestionSection>
+
+        <QuestionSection>
+          <QuestionTitle>どの思想に共感しますか？</QuestionTitle>
+          <OptionList>
+            <OptionItem>
+              <input type="checkbox" name="customer" value="" />
+              <Content>みな機会において平等であるべきだ。そして、実力があるものこそ上に立つべきだ</Content>
+            </OptionItem>
+
+            <OptionItem>
+              <input type="checkbox" name="customer" value="" />
+              <Content>明るく社交的な人物は優秀であり、暗く内向的な人物は劣等である</Content>
+            </OptionItem>
+
+            <OptionItem>
+              <input type="checkbox" name="customer" value="" />
+              <Content>とにかく分かりやすく役に立ちそうなものを使えばいい。細かいことは考える必要はない</Content>
+            </OptionItem>
+
+            <OptionItem>
+              <input type="checkbox" name="customer" value="" />
+              <Content>何が正しいかなんてわからない。そのため何事も研究が欠かせない</Content>
+            </OptionItem>
+
+            <OptionItem>
+              <input type="checkbox" name="customer" value="" />
+              <Content>思想はある種の趣味で、固有のものだから、共感できる思想はない</Content>
+            </OptionItem>
+          </OptionList>
+        </QuestionSection>
+
+        <QuestionSection>
+          <QuestionTitle>世間で言われるところの「常識」についてどう思いますか？</QuestionTitle>
+          <OptionList>
+            <OptionItem>
+              <input type="radio" name="client" value="" />
+              <Content>非常識にならないためにも、遵守すべき規範であり、絶対に守らなければならないと思う</Content>
+            </OptionItem>
+
+            <OptionItem>
+              <input type="radio" name="client" value="" />
+              <Content>常識がないやつは、変なやつだと思うので、私は嫌いだ。なお私は常識人です</Content>
+            </OptionItem>
+
+            <OptionItem>
+              <input type="radio" name="client" value="" />
+              <Content>常識の定義がいまいちわからないので、答えかねます</Content>
+            </OptionItem>
+
+            <OptionItem>
+              <input type="radio" name="client" value="" />
+              <Content>「世間の常識では」と説教する人が言う、「常識」は、その人の主観でしかないと思う</Content>
+            </OptionItem>
+
+            <OptionItem>
+              <input type="radio" name="client" value="" />
+              <Content>常識が正しいと信じ込むのは、思考停止だと思う</Content>
+            </OptionItem>
+          </OptionList>
+        </QuestionSection>
+        <Button>次の質問へ</Button>
+      </PageContainer>
     </>
   );
 }

--- a/src/app/diagnosis/page.tsx
+++ b/src/app/diagnosis/page.tsx
@@ -1,6 +1,7 @@
 'use client'
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import Header from '../components/Header'
+import Header from '../components/Header';
 
 const PageContainer = styled.div`
   display: flex;
@@ -27,7 +28,6 @@ const Button = styled.button`
     background-color: #009977;
   }
 `;
-
 
 const Title = styled.h1`
   font-size: 2rem;
@@ -61,7 +61,7 @@ const OptionList = styled.div`
 const OptionItem = styled.label`
   display: flex;
   align-items: center;
-  background: #3333CC;
+  background: #3333cc;
   padding: 0.5rem 1rem;
   border-radius: 5px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -73,96 +73,45 @@ const OptionItem = styled.label`
 `;
 
 export default function DiagnosticTest() {
+  const [diagnosisTitle, setDiagnosisTitle] = useState([]);
+  const [questions, setQuestions] = useState([]);
+
+  useEffect(() => {
+    const fetchQuestions = async () => {
+      try {
+        const response = await fetch('http://localhost:8086/diagnosis/1'); // IDは1を仮定
+        const data = await response.json();
+        setDiagnosisTitle(data.title);
+        setQuestions(data.questions);
+      } catch (error) {
+        console.error('Error fetching questions:', error);
+      }
+    };
+
+    fetchQuestions();
+  }, []);
+
   return (
     <>
       <Header />
       <PageContainer>
-        <QuestionSection>
-          <QuestionTitle>お酒を飲む頻度とそのスタイルを教えてください</QuestionTitle>
-          <OptionList>
-            <OptionItem>
-              <input type="radio" name="skill" value="営業(個人)" />
-              <Content>お酒はほとんど飲まない</Content>
-            </OptionItem>
-            <OptionItem>
-              <input type="radio" name="skill" value="" />
-              <Content>お酒は週1、2回程度飲む。お酒にあまり強くない、もしくは普通のため、付き合いでちょっと飲む程度</Content>
-            </OptionItem>
-            <OptionItem>
-              <input type="radio" name="skill" value="" />
-              <Content>ほとんど毎日飲む。好きな酒のこだわりはなく、手持ち無沙汰で飲んでいる。お酒を飲める人はかっこいいと思う</Content>
-            </OptionItem>
-            <OptionItem>
-              <input type="radio" name="skill" value="" />
-              <Content>毎日飲まなきゃやってらんない。酒の味が大好きで、仲間と飲むのが楽しいから毎日飲む</Content>
-            </OptionItem>
-
-            <OptionItem>
-              <input type="radio" name="skill" value="" />
-              <Content>毎日飲まなきゃやってらんない。たいてい一人で飲む。そして本当は酒はあまり好きじゃない</Content>
-            </OptionItem>
-          </OptionList>
-        </QuestionSection>
-
-        <QuestionSection>
-          <QuestionTitle>どの思想に共感しますか？</QuestionTitle>
-          <OptionList>
-            <OptionItem>
-              <input type="checkbox" name="customer" value="" />
-              <Content>みな機会において平等であるべきだ。そして、実力があるものこそ上に立つべきだ</Content>
-            </OptionItem>
-
-            <OptionItem>
-              <input type="checkbox" name="customer" value="" />
-              <Content>明るく社交的な人物は優秀であり、暗く内向的な人物は劣等である</Content>
-            </OptionItem>
-
-            <OptionItem>
-              <input type="checkbox" name="customer" value="" />
-              <Content>とにかく分かりやすく役に立ちそうなものを使えばいい。細かいことは考える必要はない</Content>
-            </OptionItem>
-
-            <OptionItem>
-              <input type="checkbox" name="customer" value="" />
-              <Content>何が正しいかなんてわからない。そのため何事も研究が欠かせない</Content>
-            </OptionItem>
-
-            <OptionItem>
-              <input type="checkbox" name="customer" value="" />
-              <Content>思想はある種の趣味で、固有のものだから、共感できる思想はない</Content>
-            </OptionItem>
-          </OptionList>
-        </QuestionSection>
-
-        <QuestionSection>
-          <QuestionTitle>世間で言われるところの「常識」についてどう思いますか？</QuestionTitle>
-          <OptionList>
-            <OptionItem>
-              <input type="radio" name="client" value="" />
-              <Content>非常識にならないためにも、遵守すべき規範であり、絶対に守らなければならないと思う</Content>
-            </OptionItem>
-
-            <OptionItem>
-              <input type="radio" name="client" value="" />
-              <Content>常識がないやつは、変なやつだと思うので、私は嫌いだ。なお私は常識人です</Content>
-            </OptionItem>
-
-            <OptionItem>
-              <input type="radio" name="client" value="" />
-              <Content>常識の定義がいまいちわからないので、答えかねます</Content>
-            </OptionItem>
-
-            <OptionItem>
-              <input type="radio" name="client" value="" />
-              <Content>「世間の常識では」と説教する人が言う、「常識」は、その人の主観でしかないと思う</Content>
-            </OptionItem>
-
-            <OptionItem>
-              <input type="radio" name="client" value="" />
-              <Content>常識が正しいと信じ込むのは、思考停止だと思う</Content>
-            </OptionItem>
-          </OptionList>
-        </QuestionSection>
+        {questions.map((question, index) => (
+          <QuestionSection key={index}>
+            <QuestionTitle>{question.title}</QuestionTitle>
+            <OptionList>
+              {question.choices.map((choice, idx) => (
+                <OptionItem key={idx}>
+                  <input
+                    type={question.type}
+                    name={`question-${index}`}
+                    value={choice.point}
+                  />
+                  <Content>{choice.title}</Content>
+                </OptionItem>
+              ))}
+            </OptionList>
+          </QuestionSection>
+        ))}
         <Button>次の質問へ</Button>
       </PageContainer>
     </>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { createGlobalStyle, ThemeProvider } from 'styled-components';
+import StyledComponentsRegistry from './lib/registry'
 import type { ReactNode } from 'react';
 
 const GlobalStyle = createGlobalStyle`
@@ -21,11 +22,13 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html>
       <body>
-        <GlobalStyle />
-        <ThemeProvider theme={theme}>
-          {children}
-        </ThemeProvider>
-+     </body>
+        <StyledComponentsRegistry>
+          <GlobalStyle />
+          <ThemeProvider theme={theme}>
+            {children}
+          </ThemeProvider>
+        </StyledComponentsRegistry>
+      </body>
     </html>
   );
 }

--- a/src/app/lib/registry.tsx
+++ b/src/app/lib/registry.tsx
@@ -1,0 +1,29 @@
+'use client'
+ 
+import React, { useState } from 'react'
+import { useServerInsertedHTML } from 'next/navigation'
+import { ServerStyleSheet, StyleSheetManager } from 'styled-components'
+ 
+export default function StyledComponentsRegistry({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  // Only create stylesheet once with lazy initial state
+  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet())
+ 
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement()
+    styledComponentsStyleSheet.instance.clearTag()
+    return <>{styles}</>
+  })
+ 
+  if (typeof window !== 'undefined') return <>{children}</>
+ 
+  return (
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
+      {children}
+    </StyleSheetManager>
+  )
+}


### PR DESCRIPTION
## 対応内容

- [x] 回答をDBに保存する
- [x] 質問をAPIから取得して画面に表示する
- [x] 質問の遷移においてURL遷移ではなく質問を動的に入れ替える
- [x] Styled componentsのFOUCの修正
- [x] 未入力回答がある状態で次へ押すとバリデーションエラーにする
- [x] 戻るボタンで戻っても前の回答が入力されている状態にする